### PR TITLE
fix: Pin sha of php:7.4-apache 🦭

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Site
-FROM php:7.4-apache
+FROM php:7.4-apache@sha256:c9d7e608f73832673479770d66aacc8100011ec751d1905ff63fae3fe2e0ca6d
 
 # Install jq
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This pins the sha of the Docker image for php:7.4-apache.

Relates to keymanapp/keyman.com#403