### PR TITLE
chore: Add _control/ready

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,3 +18,6 @@
 
     RewriteRule ^(build.sh|Dockerfile|.git|resources/)$ - [R=404,L]
 </IfModule>
+
+# Ready
+RewriteRule "^_control/ready$" "_control/ready.php" [END]

--- a/_control/ready.php
+++ b/_control/ready.php
@@ -1,0 +1,9 @@
+<?php
+  header("Content-Type: text/plain");
+
+  // Test web server ready
+  if (!file_exists(__DIR__ . '/../metadata/kmwversions.json')) {
+    die('/metadata/kmwversions.json not ready');
+  }
+
+  echo "ready\n";


### PR DESCRIPTION
Addresses the bullet on keymanapp/keyman.com#403

> s.keyman.com
> * ~plain text file (don't use _common)~ test web server ready
> * .htaccess rewrite?

So since s.keyman.com generates /metadata/kmwversions.json, I have /_control/ready test for the file.
