### PR TITLE
fix: properly handle paths in init-container.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.4
+readonly BOOTSTRAP_VERSION=v0.18
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
+
 echo "---- Generating static file ----"
 
-cd ./deploy
+cd "$THIS_SCRIPT_PATH/../deploy"
 ./kmwversion.sh
 cd ../


### PR DESCRIPTION
Ports fix from keymanapp/keymanweb.com#136 to make the pathing in init-container.sh robust.

Also updates BOOTSTRAP_VERSION to v0.18, but  not refactoring `/_control/info` to use `KeymanHosts` (lack of autoload.php).
