### PR TITLE
chore: add resources/keyman-site.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 # Site
 FROM php:7.4-apache@sha256:c9d7e608f73832673479770d66aacc8100011ec751d1905ff63fae3fe2e0ca6d
+COPY resources/keyman-site.conf /etc/apache2/conf-available/
 
 # Install jq
 RUN apt-get update && apt-get install -y \

--- a/resources/keyman-site.conf
+++ b/resources/keyman-site.conf
@@ -1,0 +1,1 @@
+# empty file - no specific changes needed


### PR DESCRIPTION
s.keyman.com fell over because of a missing keyman-site.conf file. This change adds it to the deployment, because it looks like the k8s configuration was depending on it existing during deployment.